### PR TITLE
Remove manual scala-library dependency

### DIFF
--- a/src/main/scala/com.felixmulder.dotty.plugin/DottyPlugin.scala
+++ b/src/main/scala/com.felixmulder.dotty.plugin/DottyPlugin.scala
@@ -9,11 +9,11 @@ object DottyPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = {
     
     val dottyVersion = sys.env.get("COMPILERVERSION") getOrElse {
-      "0.1-20170105-42eb864-NIGHTLY"
+      "0.1-20170107-a909c2f-NIGHTLY"
     }
 
     val dottyBridgeVersion = sys.env.get("BRIDGEVERSION") getOrElse {
-      "0.1.1-20170105-42eb864-NIGHTLY"
+      "0.1.1-20170107-a909c2f-NIGHTLY"
     }
 
     Seq(
@@ -26,14 +26,7 @@ object DottyPlugin extends AutoPlugin {
       // to 0.1 (the dotty version number)
       scalaBinaryVersion := "2.11",
 
-      // Don't import the stdlib for "scalaBinaryVersion"
-      autoScalaLibrary := false,
-
       libraryDependencies ++= Seq(
-        // Dotty depends on stdlib 2.11.5, best use that too (dottyVersion is
-        // actually 2.11.5, published under ch.epfl.lamp)
-        "ch.epfl.lamp" % "scala-library_2.11" % dottyVersion,
-
         // Compiler on tool path
         "ch.epfl.lamp" % "dotty_2.11" % dottyVersion % "scala-tool"
       ),


### PR DESCRIPTION
This is no longer necessary after https://github.com/lampepfl/dotty/pull/1885