### PR TITLE
Bump dotty version to 0.1.1-20170109-be64643-NIGHTLY

### DIFF
--- a/src/main/scala/com.felixmulder.dotty.plugin/DottyPlugin.scala
+++ b/src/main/scala/com.felixmulder.dotty.plugin/DottyPlugin.scala
@@ -9,11 +9,7 @@ object DottyPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = {
     
     val dottyVersion = sys.env.get("COMPILERVERSION") getOrElse {
-      "0.1-20170107-a909c2f-NIGHTLY"
-    }
-
-    val dottyBridgeVersion = sys.env.get("BRIDGEVERSION") getOrElse {
-      "0.1.1-20170107-a909c2f-NIGHTLY"
+      "0.1.1-20170109-be64643-NIGHTLY"
     }
 
     Seq(
@@ -32,7 +28,7 @@ object DottyPlugin extends AutoPlugin {
       ),
 
       // Bridge which allows REPL and compilation via dotty
-      scalaCompilerBridgeSource := ("ch.epfl.lamp" % "dotty-sbt-bridge" % dottyBridgeVersion % "component").sources()
+      scalaCompilerBridgeSource := ("ch.epfl.lamp" % "dotty-sbt-bridge" % scalaVersion.value % "component").sources()
     )
   }
 }


### PR DESCRIPTION
The compiler and bridge now share the same version number.